### PR TITLE
Feature/unicode invalid data

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "winparsingtools"
 description = "collection of structs and utilities for parsing windows binary formats."
 homepage = "https://github.com/AbdulRhmanAlfaifi/winparsingtools"
 repository = "https://github.com/AbdulRhmanAlfaifi/winparsingtools"
-version = "1.1.0"
+version = "2.0.0"
 authors = ["AbdulRhman Alfaifi <@A__ALFAIFI>"]
 edition = "2018"
 license = "MIT"
@@ -14,3 +14,4 @@ bitreader = "0.3.3"
 chrono = "0.4.19"
 serde = { features = ["derive"], version = "1.0.123"}
 serde_json = "1.0.61"
+thiserror = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ chrono = "0.4.19"
 serde = { features = ["derive"], version = "1.0.123"}
 serde_json = "1.0.61"
 thiserror = "1"
+encoding_rs = "0.8"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,3 +5,6 @@ pub mod date_time;
 pub mod file_system;
 pub mod structs;
 pub mod traits;
+
+mod reader_error;
+pub use reader_error::*;

--- a/src/reader_error.rs
+++ b/src/reader_error.rs
@@ -11,7 +11,10 @@ pub enum ReaderError {
     Utf16Error(DecodeUtf16Error),
 
     #[error("error while decoding UTF-8: {0}")]
-    Utf8Error(Utf8Error)
+    Utf8Error(Utf8Error),
+
+    #[error("unable to decode the value using CP1252")]
+    CP1252Error
 }
 
 impl From<std::io::Error> for ReaderError {

--- a/src/reader_error.rs
+++ b/src/reader_error.rs
@@ -4,7 +4,7 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum ReaderError {
-    #[error("an IO error has occurred")]
+    #[error("an IO error has occurred: {0}")]
     IoError(std::io::Error),
 
     #[error("error while decoding UTF-16: {0}")]

--- a/src/reader_error.rs
+++ b/src/reader_error.rs
@@ -1,0 +1,33 @@
+use std::{char::DecodeUtf16Error, str::Utf8Error};
+
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum ReaderError {
+    #[error("an IO error has occurred")]
+    IoError(std::io::Error),
+
+    #[error("error while decoding UTF-16: {0}")]
+    Utf16Error(DecodeUtf16Error),
+
+    #[error("error while decoding UTF-8: {0}")]
+    Utf8Error(Utf8Error)
+}
+
+impl From<std::io::Error> for ReaderError {
+    fn from(value: std::io::Error) -> Self {
+        Self::IoError(value)
+    }
+}
+
+impl From<DecodeUtf16Error> for ReaderError {
+    fn from(value: DecodeUtf16Error) -> Self {
+        Self::Utf16Error(value)
+    }
+}
+
+impl From<Utf8Error> for ReaderError {
+    fn from(value: Utf8Error) -> Self {
+        Self::Utf8Error(value)
+    }
+}

--- a/src/structs/extra_data_block.rs
+++ b/src/structs/extra_data_block.rs
@@ -1,5 +1,6 @@
-use std::io::{Result, Cursor, Read};
+use std::io::{Cursor, Read};
 use byteorder::{LittleEndian, ReadBytesExt};
+use crate::ReaderError;
 use crate::date_time::DosDateTime;
 use crate::utils::{read_utf16_string, read_utf8_string};
 use crate::file_system::FileReference;
@@ -27,11 +28,11 @@ pub struct ExtraDataBlock {
 }
 
 impl ExtraDataBlock{
-    pub fn from_buffer(buf: &[u8]) -> Result<Option<ExtraDataBlock>>{
+    pub fn from_buffer(buf: &[u8]) -> Result<Option<ExtraDataBlock>, ReaderError>{
         Self::from_reader(&mut Cursor::new(buf))
     }
 
-    pub fn from_reader<R: Read>(r: &mut R) -> Result<Option<ExtraDataBlock>>{
+    pub fn from_reader<R: Read>(r: &mut R) -> Result<Option<ExtraDataBlock>, ReaderError>{
         let size =  r.read_u16::<LittleEndian>()?;
         if size == 0 {
             return Ok(None);

--- a/src/structs/shell_items/file_entry.rs
+++ b/src/structs/shell_items/file_entry.rs
@@ -1,7 +1,7 @@
-use std::io::{Cursor, Read, Result, SeekFrom, Seek};
+use std::io::{Cursor, Read, SeekFrom, Seek};
 use byteorder::{LittleEndian, ReadBytesExt};
 use crate::date_time::DosDateTime;
-use crate::utils;
+use crate::{utils, ReaderError};
 use crate::file_system::FileAttributesFlags;
 use crate::structs::ExtraDataBlock;
 use super::Name;
@@ -19,11 +19,11 @@ pub struct FileEntryShellItem{
 }
 
 impl FileEntryShellItem{
-    pub fn from_buffer(buf: &[u8]) -> Result<Self>{
+    pub fn from_buffer(buf: &[u8]) -> Result<Self, ReaderError>{
         Self::from_reader(&mut Cursor::new(buf))
     }
 
-    pub fn from_reader<R: Read+Seek>(r: &mut R) -> Result<Self>{
+    pub fn from_reader<R: Read+Seek>(r: &mut R) -> Result<Self, ReaderError>{
         let class_type = r.read_u8()?;
         let mut is_file = false;
         let mut is_utf16 = false;

--- a/src/structs/shell_items/id_list.rs
+++ b/src/structs/shell_items/id_list.rs
@@ -1,19 +1,20 @@
+use crate::ReaderError;
 use crate::structs::shell_items::{Name, ShellItem};
 use crate::traits::Path;
 use byteorder::{LittleEndian, ReadBytesExt};
 use serde::Serialize;
-use std::io::{Cursor, Read, Result, Seek, SeekFrom};
+use std::io::{Cursor, Read, Seek, SeekFrom};
 
 /// [IDList](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-shllink/470e62dc-6c62-49c4-b205-2c39780f10f7) struct parser.
 #[derive(Debug, Serialize)]
 pub struct IDList(Vec<ShellItem>);
 
 impl IDList {
-    pub fn from_buffer(buf: &[u8]) -> Result<Self> {
+    pub fn from_buffer(buf: &[u8]) -> Result<Self, ReaderError> {
         Self::from_reader(&mut Cursor::new(buf))
     }
 
-    pub fn from_reader<R: Read + Seek>(r: &mut R) -> Result<Self> {
+    pub fn from_reader<R: Read + Seek>(r: &mut R) -> Result<Self, ReaderError> {
         let mut item_id_list = vec![];
         loop {
             let size = r.read_u16::<LittleEndian>()?;
@@ -26,6 +27,10 @@ impl IDList {
             item_id_list.push(ShellItem::from_buffer(&shell_item_data)?);
         }
         Ok(Self(item_id_list))
+    }
+
+    pub fn items<'a>(&'a self) -> std::slice::Iter<'a, ShellItem> {
+        self.0.iter()
     }
 }
 
@@ -42,3 +47,4 @@ impl Path for IDList {
         )
     }
 }
+

--- a/src/structs/shell_items/network_location.rs
+++ b/src/structs/shell_items/network_location.rs
@@ -1,6 +1,6 @@
-use std::io::{Result, Cursor, Read, Seek, SeekFrom};
+use std::io::{Cursor, Read, Seek, SeekFrom};
 use byteorder::ReadBytesExt;
-use crate::utils::read_utf8_string;
+use crate::{utils::read_utf8_string, ReaderError};
 use super::Name;
 use serde::Serialize;
 
@@ -16,11 +16,11 @@ pub struct NetworkLocationShellItem {
 }
 
 impl NetworkLocationShellItem {
-    pub fn from_buffer(buf: &[u8]) -> Result<Self>{
+    pub fn from_buffer(buf: &[u8]) -> Result<Self, ReaderError>{
         Self::from_reader(&mut Cursor::new(buf))
     }
 
-    pub fn from_reader<R: Read + Seek>(r: &mut R) -> Result<Self>{
+    pub fn from_reader<R: Read + Seek>(r: &mut R) -> Result<Self, ReaderError>{
         let _class_type = r.read_u8()?; // used to extract flags
         let mut description = None;
         let mut comments = None;

--- a/src/structs/string_data.rs
+++ b/src/structs/string_data.rs
@@ -1,7 +1,7 @@
-use std::io::{Read, Result, Cursor};
+use std::io::{Read, Cursor};
 use byteorder::{LittleEndian, ReadBytesExt};
 use std::fmt::{Formatter, Display, Result as FmtResult};
-use crate::utils::read_utf16_string;
+use crate::{utils::read_utf16_string, ReaderError};
 use serde::{Serialize, Serializer};
 
 /// [StringData](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-shllink/17b69472-0f34-4bcf-b290-eccdb8de224b) struct parser.
@@ -12,11 +12,11 @@ pub struct StringData {
 }
 
 impl StringData {
-    pub fn from_buffer(buf: &[u8]) -> Result<Self>{
+    pub fn from_buffer(buf: &[u8]) -> Result<Self, ReaderError> {
         Self::from_reader(&mut Cursor::new(buf))
     }
 
-    pub fn from_reader<R: Read>(r: &mut R) -> Result<Self>{
+    pub fn from_reader<R: Read>(r: &mut R) -> Result<Self, ReaderError> {
         let size = r.read_u16::<LittleEndian>()?;
         let string = read_utf16_string(r, Some(size as usize))?;
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -3,12 +3,9 @@
 mod rot13;
 pub use rot13::Rot13;
 
-use std::io::{self, Result, Read};
-use byteorder::{ReadBytesExt, LittleEndian};
-use std::{
-    str::from_utf8,
-    char::decode_utf16
-};
+use byteorder::{LittleEndian, ReadBytesExt};
+use std::io::{self, Read, Result};
+use std::{char::decode_utf16, str::from_utf8};
 // https://github.com/omerbenamram/mft/blob/master/src/utils.rs
 /// Read UTF-16LE string from a stream and return it as `String`.
 pub fn read_utf16_string<T: Read>(stream: &mut T, len: Option<usize>) -> Result<String> {
@@ -42,11 +39,10 @@ pub fn read_utf16_string<T: Read>(stream: &mut T, len: Option<usize>) -> Result<
 }
 
 /// Read UTF-8 string from a stream and return it as `String`.
-pub fn read_utf8_string<R: Read>(stream: &mut R, len: Option<usize>) -> Result<String> 
-{
-    let mut buffer = match len{
+pub fn read_utf8_string<R: Read>(stream: &mut R, len: Option<usize>) -> Result<String> {
+    let mut buffer = match len {
         Some(len) => Vec::with_capacity(len),
-        None => Vec::new()
+        None => Vec::new(),
     };
 
     match len {
@@ -66,5 +62,13 @@ pub fn read_utf8_string<R: Read>(stream: &mut R, len: Option<usize>) -> Result<S
             buffer.push(next_char);
         },
     }
-    from_utf8(buffer.into_iter().take_while(|&byte| byte != 0x00).collect::<Vec<u8>>().as_slice()).map_err(|_e| io::Error::from(io::ErrorKind::InvalidData)).map(|r| r.to_string())
+    from_utf8(
+        buffer
+            .into_iter()
+            .take_while(|&byte| byte != 0x00)
+            .collect::<Vec<u8>>()
+            .as_slice(),
+    )
+    .map_err(|_e| io::Error::from(io::ErrorKind::InvalidData))
+    .map(|r| r.to_string())
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,6 +1,7 @@
 //! Utilites used for formating data.
 
 mod rot13;
+use encoding_rs::WINDOWS_1252;
 pub use rot13::Rot13;
 
 use byteorder::{LittleEndian, ReadBytesExt};
@@ -79,4 +80,46 @@ pub fn read_utf8_string<R: Read>(
     )
     .map_err(ReaderError::from)
     .map(|r| r.to_string())
+}
+
+/// read a single byte string in some unknown code page.
+/// Can this happen? Yes. Consider <https://winprotocoldoc.blob.core.windows.net/productionwindowsarchives/MS-SHLLINK/%5bMS-SHLLINK%5d.pdf>
+/// which states things like `A NULL–terminated string, defined by the system default code page`
+/// 
+/// no words...
+/// 
+/// This method assumes CP1252, which is common for a lot of systems, and maps invalid characters to '?'
+/// 
+pub fn read_cp1252_string<R: Read>(
+    stream: &mut R,
+    len: Option<usize>,
+) -> Result<String, ReaderError> {
+    let mut buffer = match len {
+        Some(len) => Vec::with_capacity(len),
+        None => Vec::new(),
+    };
+
+    match len {
+        Some(len) => {
+            for _ in 0..len {
+                let next_char = stream.read_u8()?;
+                buffer.push(next_char);
+            }
+        }
+        None => loop {
+            let next_char = stream.read_u8()?;
+
+            if next_char == 0 {
+                break;
+            }
+
+            buffer.push(next_char);
+        },
+    }
+    let (cow, _encoding_used, had_errors) = WINDOWS_1252.decode(&buffer[..]);
+    if had_errors {
+        Err(ReaderError::CP1252Error)
+    } else {
+        Ok(cow.into())
+    }
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -4,11 +4,16 @@ mod rot13;
 pub use rot13::Rot13;
 
 use byteorder::{LittleEndian, ReadBytesExt};
-use std::io::{self, Read, Result};
+use std::io::{self, Read};
 use std::{char::decode_utf16, str::from_utf8};
+
+use crate::ReaderError;
 // https://github.com/omerbenamram/mft/blob/master/src/utils.rs
 /// Read UTF-16LE string from a stream and return it as `String`.
-pub fn read_utf16_string<T: Read>(stream: &mut T, len: Option<usize>) -> Result<String> {
+pub fn read_utf16_string<T: Read>(
+    stream: &mut T,
+    len: Option<usize>,
+) -> Result<String, ReaderError> {
     let mut buffer = match len {
         Some(len) => Vec::with_capacity(len),
         None => Vec::new(),
@@ -34,12 +39,15 @@ pub fn read_utf16_string<T: Read>(stream: &mut T, len: Option<usize>) -> Result<
 
     // We need to stop if we see a NUL byte, even if asked for more bytes.
     decode_utf16(buffer.into_iter().take_while(|&byte| byte != 0x00))
-        .map(|r| r.map_err(|_e| io::Error::from(io::ErrorKind::InvalidData)))
+        .map(|r| r.map_err(ReaderError::from))
         .collect()
 }
 
 /// Read UTF-8 string from a stream and return it as `String`.
-pub fn read_utf8_string<R: Read>(stream: &mut R, len: Option<usize>) -> Result<String> {
+pub fn read_utf8_string<R: Read>(
+    stream: &mut R,
+    len: Option<usize>,
+) -> Result<String, ReaderError> {
     let mut buffer = match len {
         Some(len) => Vec::with_capacity(len),
         None => Vec::new(),
@@ -69,6 +77,6 @@ pub fn read_utf8_string<R: Read>(stream: &mut R, len: Option<usize>) -> Result<S
             .collect::<Vec<u8>>()
             .as_slice(),
     )
-    .map_err(|_e| io::Error::from(io::ErrorKind::InvalidData))
+    .map_err(ReaderError::from)
     .map(|r| r.to_string())
 }


### PR DESCRIPTION
# Change 1
I found that `read_utf8_string` and `read_utf16_string` hide unicode encoding errors, because they must return `std::io::Error`. Therefore, I Introduced a new error type, `ReaderError`, which is now used by all reading functions. This struct wraps `io::Error`as well as other error types

# Change 2
I added a function `read_cp1252_string` which is required to read lnk files, because they don't use UTF-8. LNK files use 

> A NULL–terminated string, defined by the system default code page

whatever Microsoft thinks this might be. However, this seems to be a single byte character set, so I chose CP1252